### PR TITLE
adding instructions for new forked repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,11 @@ I have searched for a simple file manager that include many feature inside it fo
 Again, thank you for making and using this project, and reading my broken English this far.
 
 ## Run/build the app
-*Currently, only Windows app was fully tested* \
-Start by running `npm run start` in `src` directory. For Visual Studio Code users, you can simply press `F5` to start running the app. \
+*Currently, only Windows app was fully tested* 
+### Run
+**NodeJS are required to run/build the app (you can download it from [here](https://nodejs.dev/))** \
+After installing NodeJS, start by installing dependencies with `npm i` in `src` directory (`cd ./src`), then run `npm run start`. For Visual Studio Code users, you can simply press `F5` to start running the app. 
+### Build
 You can build both portable and setup by `make win`. If you want to make setup by `make winSetup` or `make winPort` for portable version. For manual build or people who love to make life harder, remember `user/lastSessionPath` is the folder when user first open the app (or the first folder to appear in portable version).
 
 ## Channel naming


### PR DESCRIPTION
i might be dum but ok
im not sure about this, need more testing

so i forked this repo and then tried to run and realized `node_modules` is not present. then i tried `cd ./src` (`package.json` is in `./src`) and `npm install` to download and add the modules. 
the thing added a `package-lock.json` in `./` and edited a lot of things in `./src/package-lock.json`. i ultimately deleted the generated `./package-lock.json` and reverted changes of the one in `./src` for this commit (ran again and everything worked fine).

idk but i suggest moving `package.json` and the lock one to `./` because its quite inconvenient i think (not sure).