### PR TITLE
Fix the ampersand bug

### DIFF
--- a/src/page/api.js
+++ b/src/page/api.js
@@ -30,12 +30,12 @@ ipcRenderer.on('sendDirContent', (event, message, fType) => {
             // if error
             button.style.color = 'var(--attention)'
         } else if (fType[l1] == 'f') {
-            button.setAttribute('onmousedown', `highlightItem(event, this.innerHTML, this);`);
+            button.setAttribute('onmousedown', `highlightItem(event, encodeURIComponent(this.innerHTML.replace(/&amp;/g, "&")), this);`);
             //button.setAttribute('onclick', `shell.openPath('${cdPath + ((cdPath== '/') ? '' : '/') + message[l1]}')`); // edit this for cross-platform
         } else if (fType[l1] == 'd') {
             //id directory
             button.style.color = 'var(--secondary-1)';
-            button.setAttribute('onmousedown', `highlightItem(event, this.innerHTML, this, true)`);
+            button.setAttribute('onmousedown', `highlightItem(event, encodeURIComponent(this.innerHTML.replace(/&amp;/g, "&")), this, true)`);
         };
         let element = document.getElementById('fileList');
         element.appendChild(button);


### PR DESCRIPTION
Pull request to fix the ampersand issue (#6). 
Undo the ampersand parsing of innerHTML, then encodeurl to turn ampersand (`&`) into its url encode `%26`.

This thing only affects files with ampersand so nothing else is expected to break.
Probably enough but still need to check other script for the plugin function call.